### PR TITLE
refactor: modularize database connection

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,100 +4,14 @@ var favicon = require('serve-favicon');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
-var bluebird = require('bluebird');
+
 var morgan = require('morgan');
 var passport = require('passport');
 
 //var jwt = require('jsonwebtoken');
 
-var mongoose = require('mongoose');
-
-mongoose.Promise = bluebird;
-
-
-console.log(process.env.MONGOODBURL,process.env.DBUSER,process.env.DBPSW);
-
-if (process.env.DBPSW && process.env.MONGOODBURL){
-
-  var dbUrl = process.env.MONGOODBURL ;
-  var mongoodbUrl = 'mongodb://'+dbUrl;
-  var bdpsw = encodeURIComponent(process.env.DBPSW);
-
-
-  // mongoose.connect(mongoodbUrl, { 
-  //         // sets how many times to try reconnecting
-  //         reconnectTries: 30,
-  //         // sets the delay between every retry (milliseconds)
-  //         reconnectInterval: 1000,
-  //       //  useNewUrlParser: true, 
-  //         auth:{
-  //           user: process.env.DBUSER,
-  //           password: process.env.DBPSW,
-  //           dbName:"bootcamphelper"
-
-
-
-  //           } 
-  //         },
-
-
-
-  //     )
-  mongoose.connect(mongoodbUrl, { 
-          // sets how many times to try reconnecting
-          reconnectTries: 30,
-          // sets the delay between every retry (milliseconds)
-          reconnectInterval: 1000,
-
-
-            auth: {
-              user: process.env.DBUSER,
-              password: process.env.DBPSW,
-              dbName:"bootcamphelper",
-              authSource: "admin", 
-            },
-          useNewUrlParser: false,
-
-
-
-
-          },
-
-
-
-      )
-  .then(()=> { console.log('Succesfully Connected to the Mongodb Database  at URL : '+mongoodbUrl)})
-  .catch((err)=> { console.log('not able to connect');console.log(mongoodbUrl , err)})
-  mongoose.set('useCreateIndex', true);
-  mongoose.set('debug', true);
-
-
-
-
-}
-
-else{
-
-  var dbUrl = process.env.MONGOODBURL || 'localhost:27017';
-  var mongoodbUrl = 'mongodb://'+dbUrl+'/bootcampHelper';
-
-
-  mongoose.connect(mongoodbUrl, { 
-          // sets how many times to try reconnecting
-          reconnectTries: 30,
-          // sets the delay between every retry (milliseconds)
-          reconnectInterval: 1000,
-          useNewUrlParser: true 
-          } 
-      )
-  .then(()=> { console.log('Succesfully Connected to the Mongodb Database  at URL : '+mongoodbUrl)})
-  .catch((err)=> { console.log(mongoodbUrl , err)})
-  mongoose.set('useCreateIndex', true);
-  mongoose.set('debug', true);
-
-
-} 
-
+const { connectDB } = require('./configs/db');
+connectDB();
 
 
 

--- a/configs/db.js
+++ b/configs/db.js
@@ -1,0 +1,59 @@
+const mongoose = require('mongoose');
+const bluebird = require('bluebird');
+
+mongoose.Promise = bluebird;
+
+const connectDB = async (mongoUrl) => {
+  mongoose.set('useCreateIndex', true);
+  mongoose.set('debug', true);
+
+  if (mongoUrl) {
+    return mongoose.connect(mongoUrl, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+  }
+
+  console.log(process.env.MONGOODBURL, process.env.DBUSER, process.env.DBPSW);
+
+  if (process.env.DBPSW && process.env.MONGOODBURL) {
+    const dbUrl = process.env.MONGOODBURL;
+    const mongoodbUrl = 'mongodb://' + dbUrl;
+    return mongoose.connect(mongoodbUrl, {
+      reconnectTries: 30,
+      reconnectInterval: 1000,
+      auth: {
+        user: process.env.DBUSER,
+        password: process.env.DBPSW,
+        dbName: 'bootcamphelper',
+        authSource: 'admin',
+      },
+      useNewUrlParser: false,
+    })
+      .then(() => {
+        console.log('Succesfully Connected to the Mongodb Database  at URL : ' + mongoodbUrl);
+      })
+      .catch((err) => {
+        console.log('not able to connect');
+        console.log(mongoodbUrl, err);
+      });
+  } else {
+    const dbUrl = process.env.MONGOODBURL || 'localhost:27017';
+    const mongoodbUrl = 'mongodb://' + dbUrl + '/bootcampHelper';
+    return mongoose.connect(mongoodbUrl, {
+      reconnectTries: 30,
+      reconnectInterval: 1000,
+      useNewUrlParser: true,
+    })
+      .then(() => {
+        console.log('Succesfully Connected to the Mongodb Database  at URL : ' + mongoodbUrl);
+      })
+      .catch((err) => {
+        console.log(mongoodbUrl, err);
+      });
+  }
+};
+
+const closeDB = () => mongoose.connection.close();
+
+module.exports = { connectDB, closeDB };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "nodemon ./bin/www",
-    "test": "nodemon -r dotenv/config ./bin/www"
+    "test": "mocha tests/**/*.test.js"
   },
   "dependencies": {
     "bcrypt-nodejs": "0.0.3",
@@ -25,5 +25,9 @@
     "passport": "^0.4.0",
     "passport-jwt": "^4.0.0",
     "serve-favicon": "~2.4.5"
+  },
+  "devDependencies": {
+    "mocha": "^10.2.0",
+    "mongodb-memory-server": "^8.12.1"
   }
 }

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+const { connectDB, closeDB } = require('../configs/db');
+
+describe('Database connection', function() {
+  let mongoServer;
+
+  before(async function() {
+    mongoServer = await MongoMemoryServer.create();
+    const uri = mongoServer.getUri();
+    await connectDB(uri);
+  });
+
+  after(async function() {
+    await closeDB();
+    await mongoServer.stop();
+  });
+
+  it('should connect to in-memory database', function() {
+    assert.strictEqual(mongoose.connection.readyState, 1);
+  });
+});


### PR DESCRIPTION
## Summary
- abstract mongoose connection to configs/db module
- initialize database via connectDB in app startup
- test connection using in-memory MongoDB server

## Testing
- `npm test` *(fails: mocha: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893d28c45e083258f51a5904bc2dc20