### PR TITLE
chore: setup jest for testing

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'node',
+  collectCoverage: true,
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "start": "nodemon ./bin/www",
-    "test": "mocha tests/**/*.test.js"
+    "test": "cross-env NODE_ENV=test jest"
   },
   "dependencies": {
     "bcrypt-nodejs": "0.0.3",
@@ -28,6 +28,9 @@
   },
   "devDependencies": {
     "mocha": "^10.2.0",
-    "mongodb-memory-server": "^8.12.1"
+    "mongodb-memory-server": "^8.12.1",
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3",
+    "cross-env": "^7.0.3"
   }
 }

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -1,23 +1,22 @@
-const assert = require('assert');
 const mongoose = require('mongoose');
 const { MongoMemoryServer } = require('mongodb-memory-server');
 const { connectDB, closeDB } = require('../configs/db');
 
-describe('Database connection', function() {
+describe('Database connection', () => {
   let mongoServer;
 
-  before(async function() {
+  beforeAll(async () => {
     mongoServer = await MongoMemoryServer.create();
     const uri = mongoServer.getUri();
     await connectDB(uri);
   });
 
-  after(async function() {
+  afterAll(async () => {
     await closeDB();
     await mongoServer.stop();
   });
 
-  it('should connect to in-memory database', function() {
-    assert.strictEqual(mongoose.connection.readyState, 1);
+  it('should connect to in-memory database', () => {
+    expect(mongoose.connection.readyState).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- add jest-based testing configuration
- convert DB test to Jest

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cross-env)*
- `npm test` *(fails: sh: 1: cross-env: not found)*


------
https://chatgpt.com/codex/tasks/task_e_6893eeedcdfc8325afb1d9bc19b43ad7