### PR TITLE
chore: add CI workflow for tests and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests with coverage
+        run: npm test -- --coverage
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage


### PR DESCRIPTION
## Summary
- add CI workflow running tests and uploading coverage artifact

## Testing
- `npm test -- --coverage` *(fails: Instance failed to start because a library is missing or cannot be opened: "libcrypto.so.1.1")*

------
https://chatgpt.com/codex/tasks/task_e_6893f0aad1ec83259e09e12a89a72c89